### PR TITLE
Fix error when PLAUSIBLE_HOST is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ async function handleRequest(event) {
     } else {
       // PLAUSIBLE_HOST should be the full URL to your Plausible Analytics instance
       // e.g. https://plausible.io/
-      if (PLAUSIBLE_HOST !== undefined) {
+      if (typeof PLAUSIBLE_HOST !== 'undefined') {
         const url = PLAUSIBLE_HOST + 'api/event'
         const headers = new Headers()
         headers.append('User-Agent', request.headers.get('User-Agent'))


### PR DESCRIPTION
An error would throw if `PLAUSIBLE_HOST` was undefined resulting in the worker not working. 

![img](https://cdn.auravoid.dev/images/share/TddL9vmm5mhB.png) 