### PR TITLE
Add search param pass-through 

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,13 @@ async function handleRequest(event) {
           fetch(url, { method: 'POST', headers, body: JSON.stringify(data) }),
         )
       }
+
+      const searchParams = new URL(request.url).searchParams
+      url = new URL(url)
+      searchParams.forEach((value, key) => {
+        url.searchParams.append(key, value)
+      })
+
       return new Response(null, { status: 302, headers: { Location: url } })
     }
   } else if (request.method == 'DELETE') {


### PR DESCRIPTION
When a user uses search params in their short link, it gets lost with the redirect. This change adds those parameters back into the URL before the user is directed.

Before:
`https://link.short/?query=1&foo=bar` -> `https://longlink.com/`

After:
`https://link.short/?query=1&foo=bar` -> `https://longlink.com/?query=1&foo=bar`