### PR TITLE
Allow setting a custom path for the UI

### DIFF
--- a/src/form.html
+++ b/src/form.html
@@ -184,7 +184,7 @@
 			const password = document.getElementById('password').value
 
 			const baseUrlPath = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/'
-			const url = key === '' ? baseUrlPath : baseUrlPath + key
+			const url = key === '' ? window.location.href : baseUrlPath + key
 			const method = key === '' ? 'POST' : 'PUT'
 
 			try {

--- a/src/form.html
+++ b/src/form.html
@@ -183,7 +183,8 @@
 			const value = document.getElementById('value').value
 			const password = document.getElementById('password').value
 
-			const url = key === '' ? window.location.href : window.location.href + key
+			const baseUrlPath = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + "/"
+			const url = key === '' ? baseUrlPath : baseUrlPath + key
 			const method = key === '' ? 'POST' : 'PUT'
 
 			try {

--- a/src/form.html
+++ b/src/form.html
@@ -183,7 +183,7 @@
 			const value = document.getElementById('value').value
 			const password = document.getElementById('password').value
 
-			const baseUrlPath = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + "/"
+			const baseUrlPath = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/'
 			const url = key === '' ? baseUrlPath : baseUrlPath + key
 			const method = key === '' ? 'POST' : 'PUT'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import * as st from 'simple-runtypes'
 // html.d.ts tells typescript that this is a normal thing to do
 import creationPageHtml from './form.html'
 
+const ADMIN_PATH = "/"
+
 type Variables = {
 	path: string
 	key: string
@@ -87,7 +89,7 @@ app.use('*', async (c, next) => {
 })
 
 // retrieve list of keys
-app.get('/', async (c) => {
+app.get(ADMIN_PATH, async (c) => {
 	if (c.req.header('Authorization')) {
 		if (!checkAuth(c)) {
 			return unauthorized(c)
@@ -171,7 +173,7 @@ app.delete('*', async (c) => {
 app.put('*', createLink)
 
 // add random key
-app.post('/', async (c) => {
+app.post(ADMIN_PATH, async (c) => {
 	const rawBody = await c.req.text()
 
 	if (!rawBody) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as st from 'simple-runtypes'
 // html.d.ts tells typescript that this is a normal thing to do
 import creationPageHtml from './form.html'
 
-const ADMIN_PATH = "/"
+const ADMIN_PATH = '/'
 
 type Variables = {
 	path: string


### PR DESCRIPTION
- Define an admin path in `src/index.ts`, which allows the web form to be shown on a separate url (e.g. `/links`), and the base domain to be used as a redirect source
- Update logic in the web form that assumes the form is hosted at the base domain